### PR TITLE
Infer llava model_dir if model_id is given.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+data
+results
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/log.md
+++ b/log.md
@@ -1,0 +1,29 @@
+## General TODOs
+- [ ] 2 GPU eval won't return.
+- [ ] 2 GPU eval didn't show progress bar at all. Should've appeared on the main process.
+- [x] With model_id, can't omit model_dir for llava1.5, should be able to. 
+
+## Discussion
+### Eval
+- The code is unnecessarily convoluted. On high level, eval is a simple process: 
+  - Download and process data. 
+  - Choose the prompt. 
+  - Download model and do inference. 
+  - Process results. 
+- [ ] Focus on the process and get `VQA-v2` working as the first step. 
+  - [ ] Don't understand the purpose of index dataset. Seems to be important.
+  - Even loading model is crazily convoluted just because they treat huggingface as S3. Oh my god. 
+
+## Conclusion
+- Adapt to this codebase is waste of time. Learn to do eval from scratch using llava 1.6. 
+- [AI2 olmo](https://huggingface.co/allenai/OLMo-7B) UX is way better. Use that as template. Saving versions under different branch and each branch is self-contained model to be one line loaded. 
+- The goal is still the same. Master the eval first, then dive into pretraining.
+  - I skipped rigorous eval of LLM. There is no escape since VLM would still be compared to LLM on pure language capability. 
+
+## What to learn from this repo
+- Choice of eval set. 
+- Prompt for each eval set. 
+- The purpose of index dataset.
+- Learn to build dataset and dataloader from source.  
+  - You want to expand to new dataset as soon as it's released and don't rely on the middle man service. 
+  - The purpose of huggingface is distribution. Think of it as AI instagram or youtube. It's great to showcase your work and facilitate idea cross pollination. 

--- a/scripts/datasets/prepare.py
+++ b/scripts/datasets/prepare.py
@@ -40,7 +40,7 @@ class DatasetPreparationConfig:
 
     # Path Parameters
     root_dir: Path = Path(                                      # Path to root directory for storing datasets
-        "/home/ubuntu/datasets/vlm-evaluation"
+        "./data"
     )
 
     # HF Hub Credentials (for LLaMa-2)

--- a/scripts/evaluate.py
+++ b/scripts/evaluate.py
@@ -58,7 +58,7 @@ class EvaluationConfig:
 
     # Artifact Parameters
     results_dir: Path = Path(                       # Path to results directory (writing predicted output, metrics)
-        "/home/ubuntu/prismatic-vlms/results"
+        "./results"
     )
 
     # HF Hub Credentials (for LLaMa-2)

--- a/vlm_eval/models/llava.py
+++ b/vlm_eval/models/llava.py
@@ -74,7 +74,9 @@ class LLaVa(VLM):
         temperature: float = 0.2,
         **_: str,
     ) -> None:
-        self.model_family, self.model_id, self.hub_path = model_family, model_id, run_dir
+        self.model_family, self.model_id = model_family, model_id
+        self.hub_path = LLAVA_MODELS[model_id] if model_id in LLAVA_MODELS else run_dir
+        
         self.dtype = {"fp32": torch.float32, "fp16": torch.float16, "bf16": torch.bfloat16}[load_precision]
         self.ocr = ocr
 

--- a/ws_eval_script.sh
+++ b/ws_eval_script.sh
@@ -1,0 +1,10 @@
+accelerate launch --num_processes=2 scripts/evaluate.py --model_family llava-v15 --model_id llava-v1.5-7b --dataset.type vizwiz-slim --dataset.root_dir ./data
+python scripts/evaluate.py --model_family llava-v15 --model_id llava-v1.5-7b --dataset.type vizwiz-slim --dataset.root_dir ./data
+
+accelerate launch --num_processes=2 scripts/evaluate.py --model_id prism-dinosiglip+7b --dataset.type text-vqa-slim --dataset.root_dir ./data
+python scripts/evaluate.py --model_id prism-dinosiglip+7b --dataset.type text-vqa-slim --dataset.root_dir ./data
+
+for dataset_id in 'vqa-v2-slim' 'gqa-slim' 'vizwiz-slim' 'text-vqa-slim' 'nocaps-slim' 'pope-slim' 'refcoco-slim' 'ocid-ref-slim' 'tally-qa-slim'; do CUDA_VISIBLE_DEVICES=0 python scripts/evaluate.py --model_id prism-dinosiglip+7b --dataset.type $dataset_id --dataset.root_dir ./data; done
+for dataset_id in 'vqa-v2-slim' 'gqa-slim' 'vizwiz-slim' 'text-vqa-slim' 'nocaps-slim' 'pope-slim' 'refcoco-slim' 'ocid-ref-slim' 'tally-qa-slim'; do CUDA_VISIBLE_DEVICES=1 python scripts/evaluate.py --model_family llava-v15 --model_id llava-v1.5-7b --dataset.type $dataset_id --dataset.root_dir ./data; done
+
+


### PR DESCRIPTION
Was running `python scripts/evaluate.py --model_family llava-v15 --model_id llava-v1.5-7b --model_dir liuhaotian/llava-v1.5-7b --dataset.type text-vqa-slim --dataset.root_dir /home/ubuntu/datasets/vlm-evaluation`

Can't omit `model_dir` even `model_id` is provided. Small tweak to fix it. 
